### PR TITLE
Fix for duplicate messages on re-connect

### DIFF
--- a/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
+++ b/lib/src/main/java/ua/naiksoftware/stomp/client/StompClient.java
@@ -44,6 +44,7 @@ public class StompClient {
     private ConcurrentHashMap<String, Observable<StompMessage>> mStreamMap;
     private Parser parser;
     private Subscription lifecycleSub;
+    private Subscription messagesSubscription;
     private List<StompHeader> mHeaders;
     private int heartbeat;
 
@@ -133,7 +134,7 @@ public class StompClient {
                 });
 
         isConnecting = true;
-        mConnectionProvider.messages()
+        messagesSubscription = mConnectionProvider.messages()
                 .map(StompMessage::from)
                 .doOnNext(this::callSubscribers)
                 .filter(msg -> msg.getStompCommand().equals(StompCommand.CONNECTED))
@@ -179,6 +180,7 @@ public class StompClient {
     public void disconnect() {
         resetStatus();
         lifecycleSub.unsubscribe();
+        messagesSubscription.unsubscribe();
         mConnectionProvider.disconnect().subscribe(() -> mConnected = false);
     }
 


### PR DESCRIPTION
We have to store subscription to messages in order to unsubscribe on `disconnect()`